### PR TITLE
Allow filtering by service

### DIFF
--- a/pd-notifier/background/pd-notifier.js
+++ b/pd-notifier/background/pd-notifier.js
@@ -64,6 +64,7 @@ function PagerDutyNotifier()
     self.pollInterval     = 15;    // Number of seconds between checking for new notifications.
     self.includeLowUgency = false; // Whether to include low urgency incidents.
     self.removeButtons    = false; // Whether or not to unclude the action buttons.
+    self.filterServices   = null;  // ServiceID's of services to only show alerts for. 
     self.filterUsers      = null;  // UserID's of users to only show alerts for.
     self.http             = null;  // Helper for HTTP calls.
     self.poller           = null;  // This points to the interval function so we can clear it if needed.
@@ -99,6 +100,7 @@ function PagerDutyNotifier()
             pdAPIKey: null,
             pdIncludeLowUrgency: false,
             pdRemoveButtons: false,
+            pdFilterServices: null,
             pdFilterUsers: null
         },
         function(items)
@@ -107,6 +109,7 @@ function PagerDutyNotifier()
             self.apiKey           = items.pdAPIKey;
             self.includeLowUgency = items.pdIncludeLowUrgency;
             self.removeButtons    = items.pdRemoveButtons;
+            self.filterServices   = items.pdFilterServices;
             self.filterUsers      = items.pdFilterUsers;
             callback(true);
         });
@@ -160,6 +163,12 @@ function PagerDutyNotifier()
         // Limit to high urgency if that's all the user wants.
         if (!self.includeLowUgency) { url = url + 'urgency=high&'; }
 
+        // Add a service filter if we have one.
+        if (self.filterServices && self.filterServices != null && self.filterServices != "")
+        {
+            url = url + 'service=' + self.filterServices + '&';
+        }   
+             
         // Add a user filter if we have one.
         if (self.filterUsers && self.filterUsers != null && self.filterUsers != "")
         {

--- a/pd-notifier/manifest.json
+++ b/pd-notifier/manifest.json
@@ -3,7 +3,7 @@
     "name": "PagerDuty Notifier",
     "short_name": "PD Notifier",
     "description": "Desktop notifications for your PagerDuty incidents.",
-    "version": "0.5",
+    "version": "0.6",
     "author": "Rich Adams (https://richadams.me)",
     "icons": {
          "16": "images/icon-16.png",

--- a/pd-notifier/options/options.html
+++ b/pd-notifier/options/options.html
@@ -35,6 +35,12 @@
             <span class="info">Only show notifications for incidents currently assigned to these user(s). Should be one or more user IDs (comma separated, no spaces). </span>
         </div>
 
+        <div class="option">
+            <label>Filter Services</label>
+            <input id="filter-services" type="text" size="20" />
+            <span class="info">Only show notifications for incidents from these services. Should be one or more service IDs (comma sepaarated, no spaces). </span>
+        </div>
+
         <div class="option checkbox">
             <label>Include low urgency incidents?</label>
             <input id="low-urgency" type="checkbox" />

--- a/pd-notifier/options/options.js
+++ b/pd-notifier/options/options.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', function ()
         pdAPIKey: '',
         pdIncludeLowUrgency: false,
         pdRemoveButtons: false,
+        pdFilterServices: '',
         pdFilterUsers: ''
     },
     function(items)
@@ -30,6 +31,7 @@ document.addEventListener('DOMContentLoaded', function ()
         getElement('api-key').value           = obfuscateAPIKey(items.pdAPIKey);
         getElement('low-urgency').checked     = items.pdIncludeLowUrgency;
         getElement('remove-buttons').checked  = items.pdRemoveButtons;
+        getElement('filter-services').value   = items.pdFilterServices;
         getElement('filter-users').value      = items.pdFilterUsers;
     });
 });
@@ -50,6 +52,7 @@ document.getElementById('save').addEventListener('click', function ()
         pdAccountSubdomain:  getElement('account-subdomain').value,
         pdIncludeLowUrgency: getElement('low-urgency').checked,
         pdRemoveButtons:     getElement('remove-buttons').checked,
+        pdFilterServices:    getElement('filter-services').value,
         pdFilterUsers:       getElement('filter-users').value
     },
     function()
@@ -99,8 +102,20 @@ function validateConfiguration()
         isValid = false;
     }
 
+    // Filter services shouldn't have any spaces
+    e = getElement('filter-services');
+    e.value = e.value.replace(/\s+/g, '');
+    if (e.value !== ""
+        && e.value.indexOf(" ") > -1)
+    {
+        e.className = "bad";
+        isValid = false;
+    }
+
+
     // Filter users shouldn't have any spaces.
     e = getElement('filter-users');
+    e.value = e.value.replace(/\s+/g, '');
     if (e.value !== ""
         && e.value.indexOf(" ") > -1)
     {


### PR DESCRIPTION
This allows a user to set services in the options to further filter the notifications they receive.

The use case for this (that inspired this PR) is that I'd like to get notifications for all of the incidents for a service regardless of assigned user. 

There is one other change I made, when the options are saved, I strip any whitespace out of the filterUsers and the filterServices sections inputs, since it is disallowed.
