### PR TITLE
Move to the v2 PagerDuty API so that v2 API keys are supported. 

### DIFF
--- a/pd-notifier/manifest.json
+++ b/pd-notifier/manifest.json
@@ -3,7 +3,7 @@
     "name": "PagerDuty Notifier",
     "short_name": "PD Notifier",
     "description": "Desktop notifications for your PagerDuty incidents.",
-    "version": "0.10",
+    "version": "0.11",
     "author": "Rich Adams (https://richadams.me)",
     "icons": {
          "16": "images/icon-16.png",


### PR DESCRIPTION
(Also fixed minor bug with the badge icon showing a count when it should be disabled).

Keeping the old v1 API endpoints for now, so that session based auth doesn't break for existing users.
