### PR TITLE
Add ability to filter by teams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See "[Generating a General Access REST API Key](https://support.pagerduty.com/do
 * **Account Subdomain** - (Required) The subdomain for your PagerDuty account. If your account is https://example.pagerduty.com, you would use "example".
 * **PagerDuty API Key** - (Optional) An API key for your PagerDuty account. If not provided, an active session on your subdomain is needed. If a read-only key is provided, then the Acknowledge/Resolve buttons will be non-functional.
 * **Filter Users** - (Optional) A list of comma-separated user ID's, which will only trigger notifications for incidents assigned to those users.
+* **Filter Teams** - (Optional) A list of comma-separated teams ID's, which will only trigger notifications for incidents assigned to escalation policies that belong to those teams.
 * **Filter Services** - (Optional) A list of comma-separated service ID's, which will only trigger notifications for incidents that are part of those services.
 * **Include Low Urgency Alerts?** - If checked, then you will receive notifications for low urgency alerts.
 * **Remove Ack/Resolve Buttons?** - If checked, the Acknowledge/Resolve buttons are removed from the notification. You should use this if you only wish to provide a read-only API key.

--- a/pd-notifier/background/pd-notifier.js
+++ b/pd-notifier/background/pd-notifier.js
@@ -16,6 +16,7 @@ function PagerDutyNotifier()
     self.requireInteraction = false; // Whether the notification will require user interaction to dismiss.
     self.filterServices     = null;  // ServiceID's of services to only show alerts for.
     self.filterUsers        = null;  // UserID's of users to only show alerts for.
+    self.filterTeams        = null;  // TeamID's of teams to only show alerts for.
     self.pdapi              = null;  // Helper for API calls.
     self.poller             = null;  // This points to the interval function so we can clear it if needed.
     self.showBadgeUpdates   = false; // Whether we show updates on the toolbar badge.
@@ -57,6 +58,7 @@ function PagerDutyNotifier()
             pdRequireInteraction: false,
             pdFilterServices: null,
             pdFilterUsers: null,
+            pdFilterTeams: null,
             pdShowBadgeUpdates: false,
             pdBadgeLocation: 'triggered',
         },
@@ -71,6 +73,7 @@ function PagerDutyNotifier()
             self.requireInteraction = items.pdRequireInteraction;
             self.filterServices     = items.pdFilterServices;
             self.filterUsers        = items.pdFilterUsers;
+            self.filterTeams        = items.pdFilterTeams;
             self.showBadgeUpdates   = items.pdShowBadgeUpdates;
             self.badgeLocation      = items.pdBadgeLocation;
             callback(true);
@@ -166,6 +169,15 @@ function PagerDutyNotifier()
             self.filterUsers.split(',').forEach(function(s)
             {
                 url = url + 'user_ids[]=' + s + '&';
+            });
+        }
+
+        // Add a team filter if we have one.
+        if (self.filterTeams && self.filterTeams != null && self.filterTeams != "")
+        {
+            self.filterTeams.split(',').forEach(function(s)
+            {
+                url = url + 'team_ids[]=' + s + '&';
             });
         }
 

--- a/pd-notifier/options/options.html
+++ b/pd-notifier/options/options.html
@@ -41,9 +41,19 @@
         </div>
 
         <div class="option">
+            <label>Filter Teams</label>
+            <input id="filter-teams" type="text" size="20" placeholder="P123456,PX4MPLE..." />
+            <span class="info">Only show notifications for incidents in escalation policies that belong to these team(s). Should be one or more team IDs (comma separated, no spaces). </span>
+        </div>
+
+        <div class="option">
             <label>Filter Services</label>
             <input id="filter-services" type="text" size="20" placeholder="P123456,PX4MPLE..." />
             <span class="info">Only show notifications for incidents from these services. Should be one or more service IDs (comma separated, no spaces). </span>
+        </div>
+
+        <div class="notice">
+        All filters must be satisfied for you to get a notification. So if you filter by both a user and service, the incident must be in that service and belong to that user for you to get the notification.
         </div>
 
         <hr/>

--- a/pd-notifier/options/options.js
+++ b/pd-notifier/options/options.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', function ()
         pdRequireInteraction: false,
         pdFilterServices: '',
         pdFilterUsers: '',
+        pdFilterTeams: '',
         pdShowBadgeUpdates: false,
         pdBadgeLocation: ''
     },
@@ -41,6 +42,7 @@ document.addEventListener('DOMContentLoaded', function ()
         getElement('require-interaction').checked = items.pdRequireInteraction;
         getElement('filter-services').value       = items.pdFilterServices;
         getElement('filter-users').value          = items.pdFilterUsers;
+        getElement('filter-teams').value          = items.pdFilterTeams;
         getElement('show-badge').checked          = items.pdShowBadgeUpdates;
 
         // Default to "Triggered" for badgeLocation.
@@ -80,6 +82,7 @@ document.getElementById('save').addEventListener('click', function ()
         pdRequireInteraction: getElement('require-interaction').checked,
         pdFilterServices:     getElement('filter-services').value,
         pdFilterUsers:        getElement('filter-users').value,
+        pdFilterTeams:        getElement('filter-teams').value,
         pdShowBadgeUpdates:   getElement('show-badge').checked,
         pdBadgeLocation:      badgeLocation
     },
@@ -146,9 +149,18 @@ function validateConfiguration()
         isValid = false;
     }
 
-
     // Filter users shouldn't have any spaces.
     e = getElement('filter-users');
+    e.value = e.value.replace(/\s+/g, '');
+    if (e.value !== ""
+        && e.value.indexOf(" ") > -1)
+    {
+        e.className = "bad";
+        isValid = false;
+    }
+
+    // Filter teams shouldn't have any spaces.
+    e = getElement('filter-teams');
     e.value = e.value.replace(/\s+/g, '');
     if (e.value !== ""
         && e.value.indexOf(" ") > -1)


### PR DESCRIPTION
Implements the feature requested in #16.

A new option to allow filtering by teams. Uses the `team_ids[]` optional parameter on the API call (https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1incidents/get). 

Also added a notice in the options UI to remind folks that the filters are AND'd together.
<img width="539" alt="filters" src="https://user-images.githubusercontent.com/439789/83570010-30fe0100-a4da-11ea-946a-3eeea831652d.png">
